### PR TITLE
Bind receiving socket to specific interface

### DIFF
--- a/example-inventory.yml
+++ b/example-inventory.yml
@@ -7,5 +7,4 @@ all:
   vars:
     smrt_username: admin
     smrt_password: HeyH0Password
-    smrt_host_ip_address: 10.1.0.1
-    smrt_host_mac_address: 08:60:6e:11:11:11
+    smrt_host_interface: enp2s0f0

--- a/example-playbook.yml
+++ b/example-playbook.yml
@@ -9,8 +9,7 @@
       rgl.tp_link_easy_smart_switch.smrt_config:
         username: "{{ smrt_username }}"
         password: "{{ smrt_password }}"
-        host_ip_address: "{{ smrt_host_ip_address }}"
-        host_mac_address: "{{ smrt_host_mac_address }}"
+        host_interface: "{{ smrt_host_interface }}"
         switch_mac_address: "{{ smrt_switch_mac_address }}"
         # NB undefined ports will be disabled and put in vlan 1 as untagged
         #    ports.

--- a/plugins/module_utils/network.py
+++ b/plugins/module_utils/network.py
@@ -34,7 +34,10 @@ class Network:
              if i != 'lo':
                  addr = netifaces.ifaddresses(i)
                  if netifaces.AF_INET in addr:
-                     interface = [i for x in addr[netifaces.AF_INET] if x['addr'] == ip_address][0]
+                     for x in addr[netifaces.AF_INET]:
+                         if x['addr'] == ip_address:
+                             interface = i
+                             break
 
         # Sending socket
         self.ss = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)

--- a/plugins/module_utils/switch.py
+++ b/plugins/module_utils/switch.py
@@ -453,8 +453,7 @@ if __name__ == '__main__':
 
     with open(f'{os.path.dirname(os.path.abspath(__file__))}/../../example-inventory.yml', 'r') as f:
         example_inventory = yaml.safe_load(f)
-    smrt_host_ip_address = example_inventory['all']['vars']['smrt_host_ip_address']
-    smrt_host_mac_address = example_inventory['all']['vars']['smrt_host_mac_address']
+    smrt_host_interface = example_inventory['all']['vars']['smrt_host_interface']
     smrt_switch_ip_address = list(example_inventory['all']['children']['smrt_switches']['hosts'].keys())[0]
     smrt_switch_mac_address = example_inventory['all']['children']['smrt_switches']['hosts'][smrt_switch_ip_address]['smrt_switch_mac_address']
     smrt_username = example_inventory['all']['vars']['smrt_username']
@@ -470,8 +469,7 @@ if __name__ == '__main__':
 
     switch = SmrtSwitch(
         SmrtSwitchClient(
-            smrt_host_ip_address,
-            smrt_host_mac_address,
+            smrt_host_interface,
             smrt_switch_mac_address,
             smrt_username,
             smrt_password))

--- a/plugins/module_utils/switch_client.py
+++ b/plugins/module_utils/switch_client.py
@@ -36,10 +36,10 @@ class SmrtSwitchClientInterface(object):
 
 class SmrtSwitchClient(SmrtSwitchClientInterface):
 
-    def __init__(self, host_ip_address, host_mac_address, switch_mac_address, username, password):
+    def __init__(self, host_interface, switch_mac_address, username, password):
         self._username = username
         self._password = password
-        self._network = Network(host_ip_address, host_mac_address, switch_mac_address)
+        self._network = Network(host_interface, switch_mac_address)
         self._network.login(username, password)
 
     def get_ports(self):

--- a/plugins/module_utils/switch_take_ownership_client.py
+++ b/plugins/module_utils/switch_take_ownership_client.py
@@ -25,8 +25,8 @@ class SmrtSwitchTakeOwnershipClient(SmrtSwitchTakeOwnershipClientInterface):
         self._password = password
         self._switch_ip_address = switch_ip_address
         (self._host_ip_address, self._host_ip_mask, self._host_mac_address) = self.__get_host_address()
-        (default_host_ip_address, default_host_mac_address) = self.__get_default_host_address()
-        self._network = Network(default_host_ip_address, default_host_mac_address, switch_mac_address)
+        interface = self.__get_default_interface()
+        self._network = Network(interface, switch_mac_address)
 
     def __get_host_address(self):
         for interface in netifaces.interfaces():
@@ -47,7 +47,7 @@ class SmrtSwitchTakeOwnershipClient(SmrtSwitchTakeOwnershipClientInterface):
                     return (host_ip_address, host_ip_mask, host_mac_address)
         raise Exception(f'could not find a host ip address in the same network as the switch {self._switch_ip_address}')
 
-    def __get_default_host_address(self):
+    def __get_default_interface(self):
         default_network = ip_network('192.168.0.0/24')
         for interface in netifaces.interfaces():
             if interface == 'lo':
@@ -62,7 +62,7 @@ class SmrtSwitchTakeOwnershipClient(SmrtSwitchTakeOwnershipClientInterface):
                 if default_network == network:
                     default_host_ip_address = str(inet['addr'])
                     default_host_mac_address = addresses[netifaces.AF_LINK][0]['addr']
-                    return (default_host_ip_address, default_host_mac_address)
+                    return interface
         raise Exception(f'could not find a host ip address in the default switch network {default_network}')
 
     def get_config(self):

--- a/plugins/module_utils/switch_take_ownership_client.py
+++ b/plugins/module_utils/switch_take_ownership_client.py
@@ -25,7 +25,7 @@ class SmrtSwitchTakeOwnershipClient(SmrtSwitchTakeOwnershipClientInterface):
         self._password = password
         self._switch_ip_address = switch_ip_address
         (self._host_ip_address, self._host_ip_mask, self._host_mac_address) = self.__get_host_address()
-        interface = self.__get_default_interface()
+        interface = self.__get_default_host_interface()
         self._network = Network(interface, switch_mac_address)
 
     def __get_host_address(self):
@@ -47,7 +47,7 @@ class SmrtSwitchTakeOwnershipClient(SmrtSwitchTakeOwnershipClientInterface):
                     return (host_ip_address, host_ip_mask, host_mac_address)
         raise Exception(f'could not find a host ip address in the same network as the switch {self._switch_ip_address}')
 
-    def __get_default_interface(self):
+    def __get_default_host_interface(self):
         default_network = ip_network('192.168.0.0/24')
         for interface in netifaces.interfaces():
             if interface == 'lo':

--- a/plugins/modules/smrt_config.py
+++ b/plugins/modules/smrt_config.py
@@ -25,15 +25,10 @@ options:
         description:
             - The switch password.
         type: str
-    host_ip_address:
+    host_interface:
         required: True
         description:
-            - The host ip address.
-        type: str
-    host_mac_address:
-        required: True
-        description:
-            - The host mac address.
+            - The host interface.
         type: str
     switch_mac_address:
         required: True
@@ -109,8 +104,7 @@ EXAMPLES = '''
   rgl.tp_link_easy_smart_switch.smrt_config:
     username: admin
     password: admin
-    host_ip_address: 10.1.0.1
-    host_mac_address: 08:60:6e:11:11:11
+    host_interface: enp2s0f0
     switch_mac_address: 50:d4:f7:22:22:22
     # NB undefined ports will be disabled and put in vlan 1 as untagged
     #    ports.
@@ -170,8 +164,7 @@ class SmrtConfig(AnsibleModule):
             argument_spec=dict(
                 username=dict(type='str', required=True),
                 password=dict(type='str', required=True, no_log=True),
-                host_ip_address=dict(type='str', required=True),
-                host_mac_address=dict(type='str', required=True),
+                host_interface=dict(type='str', required=True),
                 switch_mac_address=dict(type='str', required=True),
                 ports=dict(type='list', elements='dict', required=True, options=dict(
                     port=dict(type='int', required=True),
@@ -190,8 +183,7 @@ class SmrtConfig(AnsibleModule):
     def main(self):
         switch = SmrtSwitch(
             SmrtSwitchClient(
-                self.params['host_ip_address'],
-                self.params['host_mac_address'],
+                self.params['host_interface'],
                 self.params['switch_mac_address'],
                 self.params['username'],
                 self.params['password']))


### PR DESCRIPTION
This makes sure the receiving socket only gets one answer from the switch,
even if multiple interfaces are connected to the same network.
